### PR TITLE
Upgrade workflows to fix deprecation issues

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,7 @@ jobs:
           profile: minimal
           toolchain: stable
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:
@@ -49,7 +49,7 @@ jobs:
         with:
           command: test
           args: -- --nocapture
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             /tmp/.buildx-cache
@@ -57,7 +57,7 @@ jobs:
             buildx-${{ runner.os }}-${{hashFiles('Dockerfile')}}
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Docker build
         run: |
           docker buildx build --tag wait_for_db:latest --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache,mode=max --output=type=docker .

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -22,9 +22,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Tests
-        uses: actions-rs/cargo@v1
         env:
           SQLITE_DRIVER: /usr/local/opt/sqliteodbc/lib/libsqlite3odbc.dylib
           POSTGRES_DRIVER: /usr/local/opt/psqlodbc/lib/psqlodbca.so
@@ -33,14 +32,9 @@ jobs:
           POSTGRES_USERNAME: foo
           POSTGRES_PASSWORD: bar
           RUST_BACKTRACE: 1          
-        with:
-          command: test
-          args: -- --nocapture
+        run: cargo test -- --nocapture
       - name: Build release
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+        run: cargo build --release
       - run: |
           otool -L target/release/wait_for_db
           if otool -L target/release/wait_for_db | grep -q /usr/local; then


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/